### PR TITLE
Added source repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "dependencies": {
     "tape": "^4.5.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mourner/kdbush.git"
+  },
   "devDependencies": {
     "eslint": "^2.7.0",
     "eslint-config-mourner": "^2.0.0"


### PR DESCRIPTION
When trying to package your repo into webjars (http://www.webjars.org/npm), I ran into a problem in that it requires the source repository to be included in the package.json file. I've added the requested field.