### PR TITLE
Update CDN files records in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A very fast static 2D index for points based on kd-tree.",
   "module": "src/index.js",
   "main": "kdbush.js",
-  "jsdelivr": "dist/kdbush.min.js",
-  "unpkg": "dist/kdbush.min.js",
+  "jsdelivr": "kdbush.min.js",
+  "unpkg": "kdbush.min.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/mourner/kdbush.git"


### PR DESCRIPTION
Now unpkg is returning an error
```
Cannot find "/dist/kdbush.min.js" in kdbush@2.0.1
```
I fixed the references to the built file in `package.json`