### PR TITLE
Pick dtype for the index array automatically and set the default dtype for coordinates to `Float32Array`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+node_modules
+package-lock.json
 kdbush.js
 kdbush.min.js
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Creates an index from the given points.
 - `points`: Input array of points.
 - `getX`, `getY`: Functions to get `x` and `y` from an input point. By default, it assumes `[x, y]` format.
 - `nodeSize`: Size of the KD-tree node, `64` by default. Higher means faster indexing but slower search, and vise versa.
-- `arrayType`: Array type to use for storing coordinate values. `Float32Array` by default, but if your coordinates are integer values, `Int32Array` makes things a bit faster.
+- `arrayType`: Array type to use for storing coordinate values. `Float64Array` by default, but if your coordinates are integer values, `Int32Array` makes things a bit faster.
 
 ```js
 var index = kdbush(points, (p) => p.x, (p) => p.y, 64, Int32Array);

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Creates an index from the given points.
 - `points`: Input array of points.
 - `getX`, `getY`: Functions to get `x` and `y` from an input point. By default, it assumes `[x, y]` format.
 - `nodeSize`: Size of the KD-tree node, `64` by default. Higher means faster indexing but slower search, and vise versa.
-- `arrayType`: Array type to use for storing indices and coordinate values. `Array` by default, but if your coordinates are integer values, `Int32Array` makes things a bit faster.
+- `arrayType`: Array type to use for storing coordinate values. `Float32Array` by default, but if your coordinates are integer values, `Int32Array` makes things a bit faster.
 
 ```js
 var index = kdbush(points, (p) => p.x, (p) => p.y, 64, Int32Array);

--- a/src/index.js
+++ b/src/index.js
@@ -10,12 +10,14 @@ export default function kdbush(points, getX, getY, nodeSize, ArrayType) {
 function KDBush(points, getX, getY, nodeSize, ArrayType) {
     getX = getX || defaultGetX;
     getY = getY || defaultGetY;
-    ArrayType = ArrayType || Array;
+    ArrayType = ArrayType || Float32Array;
 
     this.nodeSize = nodeSize || 64;
     this.points = points;
 
-    this.ids = new ArrayType(points.length);
+    const IndexArrayType = points.length < 65536 ? Uint16Array : Uint32Array;
+
+    this.ids = new IndexArrayType(points.length);
     this.coords = new ArrayType(points.length * 2);
 
     for (var i = 0; i < points.length; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default function kdbush(points, getX, getY, nodeSize, ArrayType) {
 function KDBush(points, getX, getY, nodeSize, ArrayType) {
     getX = getX || defaultGetX;
     getY = getY || defaultGetY;
-    ArrayType = ArrayType || Float32Array;
+    ArrayType = ArrayType || Float64Array;
 
     this.nodeSize = nodeSize || 64;
     this.points = points;


### PR DESCRIPTION
Addressing #20 similarly to how [flatbush](https://github.com/mourner/flatbush/blob/master/index.js#L47) handles it.