### PR TITLE
add export/import functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,31 @@ Finds all items within a given radius from the query point and returns an array 
 ```js
 const results = index.within(10, 10, 5).map(id => points[id]);
 ```
+
+#### export/import
+
+You can export an index, e.g. to store it on disk, and import it again.
+
+```js
+const index1 = new KDBush(points, p => p.x, p => p.y, 32, Int32Array);
+
+// export
+const exported = index1.export();
+fs.writeFileSync('index.json', JSON.stringify({
+    nodeSize: exported.nodeSize,
+    idsData: idsData.toString('hex'),
+    idsType: idsType.name,
+    coordsData: coordsData.toString('hex'),
+    coordsType: coordsType.name
+}));
+
+// import
+const imported = JSON.parse(fs.writeFileSync('index.json'));
+const index2 = KDBush.from({
+	nodeSize: imported.nodeSize,
+	idsData: Buffer.from(imported.idsData, 'hex'),
+	idsType: global[idsType],
+	coordsData: Buffer.from(imported.coordsData, 'hex'),
+	coordsType: global[coordsType]
+});
+```

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,9 @@ export default class KDBush {
         this.nodeSize = nodeSize;
         this.points = points;
 
+        this.ArrayType = ArrayType;
         const IndexArrayType = points.length < 65536 ? Uint16Array : Uint32Array;
+        this.IndexArrayType = IndexArrayType;
 
         // store indices to the input array and coordinates in separate typed arrays
         const ids = this.ids = new IndexArrayType(points.length);
@@ -33,5 +35,26 @@ export default class KDBush {
 
     within(x, y, r) {
         return within(this.ids, this.coords, x, y, r, this.nodeSize);
+    }
+
+    export() {
+        return {
+            nodeSize: this.nodeSize,
+            idsData: this.ids.buffer,
+            idsType: this.IndexArrayType,
+            coordsData: this.coords.buffer || this.coords,
+            coordsType: this.ArrayType
+        };
+    }
+
+    static from(exported) {
+        const {nodeSize, idsData, coordsData} = exported;
+        const IdsType = exported.idsType;
+        const CoordsType = exported.coordsType;
+
+        const instance = new KDBush([], () => {}, () => {}, nodeSize);
+        instance.ids = new IdsType(idsData);
+        instance.coords = new CoordsType(coordsData);
+        return instance;
     }
 }

--- a/test.js
+++ b/test.js
@@ -87,6 +87,18 @@ test('radius search', (t) => {
     t.end();
 });
 
+test('import/export', (t) => {
+    const getX = p => p[0];
+    const getY = p => p[1];
+    const index1 = new KDBush(points, getX, getY, 10);
+    const result1 = index1.within(50, 50, 20);
+    const index2 = KDBush.from(index1.export());
+    const result2 = index2.within(50, 50, 20);
+
+    t.same(result2, result1, 'imported index returns equal data');
+    t.end();
+});
+
 function sqDist(a, b) {
     const dx = a[0] - b[0];
     const dy = a[1] - b[1];


### PR DESCRIPTION
The `idsType`/`coordsType` hack is really ugly. Not sure what's a better way to serialise the type of `index.ids` and `index.coords`.