### PR TITLE
Add .toJSON() and .fromJSON()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,17 @@ Finds all items within a given radius from the query point and returns an array 
 ```js
 const results = index.within(10, 10, 5).map(id => points[id]);
 ```
+
+#### index.toJSON() and KDBush.fromJSON(data[, getX, getY, arrayType])
+
+Importing and exporting as JSON allows you to serialise the sorted data, meaning you can cache the sorted data or do the work of sorting in another place (for example, sorting on the server and then using it on the client).
+
+```js
+// export data as JSON object
+const index = new KDBush(points, p => p.x, p => p.y);
+
+const json = index.toJSON();
+
+// import previously imported data
+const index = KDBush.fromJSON(json, p => p.x, p => p.y);
+```

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,10 @@ export default class KDBush {
         this.nodeSize = nodeSize;
         this.points = points;
 
+        if (!points.length) {
+            return this;
+        }
+
         const IndexArrayType = points.length < 65536 ? Uint16Array : Uint32Array;
 
         // store indices to the input array and coordinates in separate typed arrays
@@ -34,4 +38,27 @@ export default class KDBush {
     within(x, y, r) {
         return within(this.ids, this.coords, x, y, r, this.nodeSize);
     }
+
+    toJSON() {
+        return {
+            ids: Array.from(this.ids),
+            coords: Array.from(this.coords),
+            nodeSize: this.nodeSize
+        };
+    }
 }
+
+KDBush.fromJSON = function (data, getX, getY, ArrayType = Float64Array) {
+    if (typeof data === 'string') {
+        data = JSON.parse(data);
+    }
+
+    const index = new KDBush([], getX, getY, data.nodeSize, ArrayType);
+
+    const IndexArrayType = data.ids.length < 65536 ? Uint16Array : Uint32Array;
+
+    index.ids = IndexArrayType.from(data.ids);
+    index.coords = ArrayType.from(data.coords);
+
+    return index;
+};

--- a/test.js
+++ b/test.js
@@ -87,6 +87,17 @@ test('radius search', (t) => {
     t.end();
 });
 
+test('json export and import', (t) => {
+    const index = new KDBush(points, undefined, undefined, 10);
+    const json = JSON.stringify(index.toJSON());
+    const index2 = KDBush.fromJSON(json);
+
+    t.same(index2.ids, ids, 'ids are kd-sorted');
+    t.same(index2.coords, coords, 'coords are kd-sorted');
+
+    t.end();
+});
+
 function sqDist(a, b) {
     const dx = a[0] - b[0];
     const dy = a[1] - b[1];


### PR DESCRIPTION
API is slightly different to rbush (didn't realise it had this when I started), can change if required.

Can also change it to just be `new KDBush(data)`, as it can detect if it's an object or array.

----

My case for this is that we're deploying something on a serverless architecture that reads points from redis - sorting on every single request is super inefficient and is adding a lot of overhead, this change would enable us to store already sorted data in redis.