### PR TITLE
Fix for odd-numbered index sizes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,13 +31,13 @@ export default class KDBush {
 
         this.numItems = +numItems;
         this.nodeSize = Math.min(Math.max(+nodeSize, 2), 65535);
-
         this.ArrayType = ArrayType;
         this.IndexArrayType = numItems < 65536 ? Uint16Array : Uint32Array;
 
         const arrayTypeIndex = ARRAY_TYPES.indexOf(this.ArrayType);
         const coordsByteSize = numItems * 2 * this.ArrayType.BYTES_PER_ELEMENT;
         const idsByteSize = numItems * this.IndexArrayType.BYTES_PER_ELEMENT;
+        const padCoords = idsByteSize % 8;
 
         if (arrayTypeIndex < 0) {
             throw new Error(`Unexpected typed array class: ${ArrayType}.`);
@@ -46,14 +46,14 @@ export default class KDBush {
         if (data && (data instanceof ArrayBuffer)) { // reconstruct an index from a buffer
             this.data = data;
             this.ids = new this.IndexArrayType(this.data, HEADER_SIZE, numItems);
-            this.coords = new this.ArrayType(this.data, HEADER_SIZE + idsByteSize, numItems * 2);
+            this.coords = new this.ArrayType(this.data, HEADER_SIZE + idsByteSize + padCoords, numItems * 2);
             this._pos = numItems * 2;
             this._finished = true;
 
         } else { // initialize a new index
-            this.data = new ArrayBuffer(HEADER_SIZE + coordsByteSize + idsByteSize);
+            this.data = new ArrayBuffer(HEADER_SIZE + coordsByteSize + idsByteSize + padCoords);
             this.ids = new this.IndexArrayType(this.data, HEADER_SIZE, numItems);
-            this.coords = new this.ArrayType(this.data, HEADER_SIZE + idsByteSize, numItems * 2);
+            this.coords = new this.ArrayType(this.data, HEADER_SIZE + idsByteSize + padCoords, numItems * 2);
             this._pos = 0;
             this._finished = false;
 


### PR DESCRIPTION
Fantastic library, thanks for you work.

Very excited to see the flat array stuff in https://github.com/mourner/kdbush/pull/32. Working on integrating that into a project currently, I've come across a little bug in the new version. When attempting to insert an odd-numbered numbers of points into the index, I get the following error:

```
RangeError: start offset of Float32Array should be a multiple of 4
    at new Float32Array (<anonymous>)
    at new KDBush (index.js:56)
    at new ArrowTree (ArrowTree.js:14)
    at tile.js:422
```

If the indexes are UInt8 and the data are Float32, the offsets won't line up right unless the number of points in the index happens to be a multiple of 2. (Or 4 if it's Float64).

Adding a couple bytes of padding to the buffer where necessary, as in this pull request, fixes the issue (as far as I can tell.)