### PR TITLE
Added basic comparison of flatbush and kdbush

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^0.21.1",
+    "benchmark": "^2.1.4",
     "eslint": "^6.8.0",
     "eslint-config-mourner": "^3.0.0",
     "esm": "^3.2.25",
+    "flatbush": "^3.3.0",
+    "ngraph.random": "^1.1.0",
     "rollup": "^2.2.0",
     "rollup-plugin-terser": "^5.3.0",
     "tape": "^4.13.2"

--- a/perf/runBenchmark.js
+++ b/perf/runBenchmark.js
@@ -1,0 +1,67 @@
+// A simple script to compare performance of KDBush to flatbush
+const KDBush = require('../kdbush');
+const Flatbush = require('flatbush');
+
+const Benchmark = require('benchmark');
+
+// use deterministic randomness, to guarantee reproducible results.
+const random = require('ngraph.random')(42);
+
+const totalPoints = 100000;
+const distributionRadius = 1000; // range of the uniform distribution
+const uniformlyDistributedPoints = [];
+
+for (let i = 0; i < totalPoints; ++i) {
+    uniformlyDistributedPoints.push([
+        (random.nextDouble() - 0.5) * distributionRadius,
+        (random.nextDouble() - 0.5) * distributionRadius,
+    ]);
+}
+
+// Going to store nearest neighbors counts, so that V8 doesn't deoptimize unused variables.
+let lengths;
+const suite = new Benchmark.Suite();
+
+suite
+    .add('kdbush', () => {
+        const index = new KDBush(uniformlyDistributedPoints);
+        lengths = [];
+        for (let i = 0; i < 10; ++i) {
+            lengths.push(index.within(i, i, 10).length);
+        }
+    })
+    .add('flatbush', () => {
+        const index = new Flatbush(uniformlyDistributedPoints.length);
+        for (let i = 0; i < uniformlyDistributedPoints.length; ++i) {
+            const p = uniformlyDistributedPoints[i];
+            index.add(p[0], p[1], p[0], p[1]);
+        }
+        index.finish();
+
+        lengths = [];
+        for (let i = 0; i < 10; ++i) {
+            lengths.push(index.neighbors(i, i, Infinity, 10).length);
+        }
+    })
+    .on('cycle', (event) => {
+    // given that input array is always the same, we should expect that all methods
+    // return the same number of neighbors. Note, this is a bit fragile, since change
+    // in the seed/number of input points would result in different numbers here.
+        if (!arrayEquals(lengths, [46, 47, 50, 48, 44, 39, 34, 34, 28, 31]))
+            throw new Error('Something is wrong. Unexpected lengths');
+        console.log(String(event.target));
+    })
+    .on('complete', function () {
+        // eslint-disable-next-line no-invalid-this
+        console.log(`Fastest is ${this.filter('fastest').map('name')}`);
+    })
+    .run({async: true});
+
+function arrayEquals(a, b) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; ++i) {
+        if (a[i] !== b[i]) return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Was just curious to see which one is faster. The test is obviously not complete, but gives a good starting point for more tests (e.g. different distributions/different search count, etc.)

For the basic example I indexed 100,000 uniformly distributed points inside [-1,000; 1,000) region and then performed 10 lookups using both algorithms. Got this result:

```
> node perf/runBenchmark.js
kdbush x 42.65 ops/sec ±0.68% (55 runs sampled)
flatbush x 52.67 ops/sec ±0.32% (66 runs sampled)
Fastest is flatbush

> npm version
{
  kdbush: '3.0.0',
  npm: '6.14.5',
  ares: '1.16.0',
  brotli: '1.0.7',
  cldr: '37.0',
  icu: '67.1',
  llhttp: '2.0.4',
  modules: '83',
  napi: '6',
  nghttp2: '1.41.0',
  node: '14.4.0',
  openssl: '1.1.1g',
  tz: '2019c',
  unicode: '13.0',
  uv: '1.37.0',
  v8: '8.1.307.31-node.33',
  zlib: '1.2.11'
}
```

Note, if we perform more searches (e.g. a `1,000`), the difference between two modules becomes negligible. 

