### PR TITLE
fix incorrect padCoords

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ export default class KDBush {
         const arrayTypeIndex = ARRAY_TYPES.indexOf(this.ArrayType);
         const coordsByteSize = numItems * 2 * this.ArrayType.BYTES_PER_ELEMENT;
         const idsByteSize = numItems * this.IndexArrayType.BYTES_PER_ELEMENT;
-        const padCoords = idsByteSize % 8;
+        const padCoords = (8 - idsByteSize % 8) % 8;
 
         if (arrayTypeIndex < 0) {
             throw new Error(`Unexpected typed array class: ${ArrayType}.`);


### PR DESCRIPTION
 The calculation of padCoords may be incorrect.
below construction will be failed with error message, for example.
`new KDBush(43)`

> RangeError: start offset of Float64Array should be a multiple of 8
    at new Float64Array (<anonymous>)
    at new KDBush (/home/kikitte/my-project/kdbush/index.js:55:27)
    at Object.<anonymous> (/home/kikitte/my-project/kdbush/test-2.js:4:1)
    at Generator.next (<anonymous>)