### PR TITLE
Add SharedArrayBuffer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ Alternatively, there's a browser bundle with a `KDBush` global variable:
 
 ## API
 
-#### new KDBush(numItems[, nodeSize, ArrayType])
+#### new KDBush(numItems[, nodeSize, ArrayType, ArrayBufferType])
 
 Creates an index that will hold a given number of points (`numItems`). Additionally accepts:
 
 - `nodeSize`: Size of the KD-tree node, `64` by default. Higher means faster indexing but slower search, and vise versa.
 - `ArrayType`: Array type to use for storing coordinate values. `Float64Array` by default, but if your coordinates are integer values, `Int32Array` makes the index faster and smaller.
+- `ArrayBufferType`: the array buffer type used to store data (`ArrayBuffer` by default);
+you may prefer `SharedArrayBuffer` if you want to share the index between threads (multiple `Worker`, `SharedWorker` or `ServiceWorker`).
 
 #### index.add(x, y)
 
@@ -89,7 +91,7 @@ Finds all items within a given radius from the query point and returns an array 
 
 #### `KDBush.from(data)`
 
-Recreates a KDBush index from raw `ArrayBuffer` data
+Recreates a KDBush index from raw `ArrayBuffer` or `SharedArrayBuffer` data
 (that's exposed as `index.data` on a previously indexed KDBush instance).
 Very useful for transferring or sharing indices between threads or storing them in a file.
 

--- a/test.js
+++ b/test.js
@@ -27,8 +27,8 @@ const coords = [
     53,49,60,50,68,57,70,56,77,63,86,71,90,52,83,71,82,72,81,94,51,75,53,95,39,78,53,88,62,84,72,77,73,99,76,73,81,88,
     87,96,98,96,82];
 
-function makeIndex() {
-    const index = new KDBush(points.length, 10);
+function makeIndex(ArrayBufferType = ArrayBuffer) {
+    const index = new KDBush(points.length, 10, undefined, ArrayBufferType);
     for (const [x, y] of points) index.add(x, y);
     return index.finish();
 }
@@ -118,6 +118,17 @@ test('does not complain about zero items', () => {
         assert.deepEqual(index.range(0, 0, 10, 10), []);
         assert.deepEqual(index.within(0, 0, 10), []);
     });
+});
+
+test('creates an index using SharedArrayBuffer', () => {
+    const index = makeIndex(SharedArrayBuffer);
+    assert(index.data instanceof SharedArrayBuffer);
+});
+
+test('reconstructs an index from a SharedArrayBuffer', () => {
+    const index = makeIndex(SharedArrayBuffer);
+    const index2 = KDBush.from(index.data);
+    assert.deepEqual(index, index2);
 });
 
 function sqDist(a, b) {


### PR DESCRIPTION
This PR adds support for [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) which is a fully compatible alternative to ArrayBuffer. 

This implementation aims to follow the style used for the [PR that added SharedArrayBuffer support in flatbush](https://github.com/mourner/flatbush/pull/46).

Addresses https://github.com/mourner/kdbush/issues/47